### PR TITLE
feat: background mode

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -55,6 +55,15 @@ fn main() {
                 get_machine_id
             ]
         )
+        .on_window_event(|event| {
+            match event.event() {
+                tauri::WindowEvent::CloseRequested { api, .. } => {
+                    event.window().hide().unwrap();
+                    api.prevent_close();
+                }
+                _ => {}
+            }
+        })
         .system_tray(tray)
         ///// SystemTray Event handlers
         .on_system_tray_event(|app, event| {
@@ -67,6 +76,9 @@ fn main() {
                 }
                 SystemTrayEvent::DoubleClick { position: _, size: _, .. } => {
                     println!("system tray received a double click");
+                    let window = app.get_window("tymtLauncher").unwrap();
+                    window.show().unwrap();
+                    window.set_focus().unwrap();
                 }
                 SystemTrayEvent::MenuItemClick { id, .. } =>
                     match id.as_str() {

--- a/src/pages/wallet/index.tsx
+++ b/src/pages/wallet/index.tsx
@@ -75,6 +75,7 @@ const Wallet = () => {
     setNotificationTitle,
     setNotificationDetail,
     setNotificationOpen,
+    setNotificationLink,
   } = useNotification();
 
   useEffect(() => {
@@ -106,6 +107,7 @@ const Wallet = () => {
           setNotificationTitle(t("alt-20_balances-refresh"));
           setNotificationDetail(t("alt-21_balances-refresh-success"));
           setNotificationStatus("success");
+          setNotificationLink(null);
         });
       });
     } else {
@@ -140,6 +142,7 @@ const Wallet = () => {
           setNotificationTitle(t("alt-20_balances-refresh"));
           setNotificationDetail(t("alt-21_balances-refresh-success"));
           setNotificationStatus("success");
+          setNotificationLink(null);
         });
       });
     });


### PR DESCRIPTION
tymtLauncher will be running in the background after you close the window.
You can make tymtLauncher visible by double-clicking on the system tray icon.