### PR TITLE
fix(gitignore): rm yarn.lock + crypto module ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules/*
-!node_modules/@solar-network/crypto/package.json
 dist
 dist-ssr
 src/consts/testMnemonics.ts
@@ -34,6 +33,3 @@ configs/*
 *.njsproj
 *.sln
 *.sw?
-
-yarn.lock
-


### PR DESCRIPTION
The `.gitignore` file lost recent changes for some reason.

This PR re-removes those lines:
- `yarn.lock`
- `!node_modules/@solar-network/crypto/package.json`