### PR TITLE
fix: game download behavior

### DIFF
--- a/src-tauri/src/file.rs
+++ b/src-tauri/src/file.rs
@@ -442,6 +442,15 @@ pub async fn delete_file(_app_handle: tauri::AppHandle, file_location: String) -
 }
 
 #[tauri::command]
+pub async fn dir_exists(
+    _app_handle: tauri::AppHandle,
+    path: String,
+) -> Result<bool, String> {
+    let path_buf = PathBuf::from(path);
+    Ok(path_buf.exists())
+}
+
+#[tauri::command]
 pub async fn delete_directory(
     _app_handle: tauri::AppHandle,
     dir_location: String,

--- a/src-tauri/src/file.rs
+++ b/src-tauri/src/file.rs
@@ -319,10 +319,8 @@ pub async fn download_to_app_dir(
 
     if let Some(parent) = path.parent() {
         if !parent.exists() {
-            match fs::create_dir_all(&parent) {
-                Err(why) => panic!("couldn't create directory: {}", why),
-                Ok(_) => println!("Successfully created the directory"),
-            }
+            fs::create_dir_all(&parent)
+                .map_err(|e| format!("Failed to create directory: {}", e))?;
         }
     }
 

--- a/src-tauri/src/file.rs
+++ b/src-tauri/src/file.rs
@@ -15,6 +15,7 @@ use debpkg::DebPkg;
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::PermissionsExt;
 
+// TODO: This function is identical to unzip_windows - they should be consolidated
 #[tauri::command]
 pub async fn unzip_linux(
     _app_handle: tauri::AppHandle,
@@ -34,7 +35,24 @@ pub async fn unzip_linux(
         let mut file = archive
             .by_index(i)
             .map_err(|e| format!("Failed to access file in zip: {}", e))?;
+
+        // Check for path traversal attempts
+        let file_path = Path::new(file.name());
+        for component in file_path.components() {
+            match component {
+                std::path::Component::ParentDir | std::path::Component::RootDir => {
+                    return Err(format!("Invalid path in archive: {}", file.name()));
+                }
+                _ => {}
+            }
+        }
+
         let out_path = extract_path.join(file.name());
+
+        // Final safety check: ensure the path stays within extract directory
+        if !out_path.starts_with(&extract_path) {
+            return Err(format!("Path traversal attempt: {}", file.name()));
+        }
 
         if file.is_dir() {
             // Create directories
@@ -171,6 +189,7 @@ pub async fn set_permission(
     Ok(())
 }
 
+// TODO: This function is identical to unzip_linux - they should be consolidated
 #[tauri::command]
 pub async fn unzip_windows(
     _app_handle: tauri::AppHandle,
@@ -190,7 +209,24 @@ pub async fn unzip_windows(
         let mut file = archive
             .by_index(i)
             .map_err(|e| format!("Failed to access file in zip: {}", e))?;
+
+        // Check for path traversal attempts
+        let file_path = Path::new(file.name());
+        for component in file_path.components() {
+            match component {
+                std::path::Component::ParentDir | std::path::Component::RootDir => {
+                    return Err(format!("Invalid path in archive: {}", file.name()));
+                }
+                _ => {}
+            }
+        }
+
         let out_path = extract_path.join(file.name());
+
+        // Final safety check: ensure the path stays within extract directory
+        if !out_path.starts_with(&extract_path) {
+            return Err(format!("Path traversal attempt: {}", file.name()));
+        }
 
         if file.is_dir() {
             // Create directories

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,6 +134,7 @@ pub fn main() -> std::io::Result<()> {
             file::run_deb_linux,
             file::delete_file,
             file::delete_directory,
+            file::dir_exists,
             file::write_file,
             file::run_url_args,
             file::open_directory,

--- a/src/components/game/InstallButton.tsx
+++ b/src/components/game/InstallButton.tsx
@@ -12,7 +12,13 @@ import { useNotification } from "../../providers/NotificationProvider";
 
 import { getDownloadStatus, resetDownloadStatus } from "../../store/DownloadStatusSlice";
 
-import { /*checkOnline,*/ downloadAndInstallNewGame, getFullExecutablePathNewGame, getGameReleaseBrowser, isInstalled } from "../../lib/helper/DownloadHelper";
+import {
+  /*checkOnline,*/
+  downloadAndInstallNewGame,
+  getGameReleaseBrowser,
+  getGameReleaseNative,
+  isInstalled
+} from "../../lib/helper/DownloadHelper";
 
 import { CONST_GAME_DISTRICT53 } from "../../const/games/district53/District53";
 
@@ -133,9 +139,12 @@ const InstallButton = ({ game, purchased, setOpenBuyGameModal, purchaseLoading }
 
   useEffect(() => {
     const checkSupport = async () => {
-      const fullPath = await getFullExecutablePathNewGame(game);
-      if (!fullPath) setIsSupporting(false);
-      else setIsSupporting(true);
+      if (game?.projectMeta?.type === "browser") {
+        setIsSupporting(true);
+        return;
+      }
+      const release = await getGameReleaseNative(game);
+      setIsSupporting(!!release);
     };
     checkSupport();
   }, [game]);

--- a/src/components/game/InstallButton.tsx
+++ b/src/components/game/InstallButton.tsx
@@ -143,19 +143,24 @@ const InstallButton = ({ game, purchased, setOpenBuyGameModal, purchaseLoading }
 
   useEffect(() => {
     const checkSupport = async () => {
+      console.time(`checkSupport for ${game.project_name}`);
       if (game?.projectMeta?.type === "browser") {
         setIsSupporting(true);
+        console.timeEnd(`checkSupport for ${game.project_name}`);
         return;
       }
       const release = await getGameReleaseNative(game);
       setIsSupporting(!!release);
+      console.timeEnd(`checkSupport for ${game.project_name}`);
     };
     checkSupport();
   }, [game._id]);
 
   useEffect(() => {
     const checkInstalled = async (game: IGame) => {
+      console.time(`checkInstalled useEffect for ${game.project_name}`);
       setInstalled(await isInstalled(game));
+      console.timeEnd(`checkInstalled useEffect for ${game.project_name}`);
     };
 
     checkInstalled(game);

--- a/src/components/game/InstallButton.tsx
+++ b/src/components/game/InstallButton.tsx
@@ -108,8 +108,12 @@ const InstallButton = ({ game, purchased, setOpenBuyGameModal, purchaseLoading }
         else setModalView(true);
         return;
       }
+      setInstalling(true);
       const id = game?.project_name;
-      if (!id) return;
+      if (!id) {
+        setInstalling(false);
+        return;
+      }
       // const online = await checkOnline();
       // if (!online) {
       //   showNotification({ content: CONST_NOTIFICATION_CONTENTS.INTERNET_ERROR });

--- a/src/components/game/InstallButton.tsx
+++ b/src/components/game/InstallButton.tsx
@@ -147,7 +147,7 @@ const InstallButton = ({ game, purchased, setOpenBuyGameModal, purchaseLoading }
       setIsSupporting(!!release);
     };
     checkSupport();
-  }, [game]);
+  }, [game._id]);
 
   useEffect(() => {
     const checkInstalled = async (game: IGame) => {
@@ -155,7 +155,7 @@ const InstallButton = ({ game, purchased, setOpenBuyGameModal, purchaseLoading }
     };
 
     checkInstalled(game);
-  }, [game]);
+  }, [game._id]);
 
   const isDownloading = !!downloadStatusStore?.game_id;
   const isNativeGame = game?.projectMeta?.type === "native";

--- a/src/components/game/InstallButton.tsx
+++ b/src/components/game/InstallButton.tsx
@@ -157,12 +157,20 @@ const InstallButton = ({ game, purchased, setOpenBuyGameModal, purchaseLoading }
     checkInstalled(game);
   }, [game]);
 
+  const isDownloading = !!downloadStatusStore?.game_id;
+  const isNativeGame = game?.projectMeta?.type === "native";
+
   return (
     <>
       <Button
         fullWidth
         onClick={handleClick}
-        disabled={!isSupporting || !!downloadStatusStore?.game_id || purchaseLoading || installing}
+        disabled={
+          !isSupporting ||
+          (isNativeGame && isDownloading) ||
+          purchaseLoading ||
+          installing
+        }
         sx={{
           height: "46px",
           width: "226px",

--- a/src/components/game/InstallButton.tsx
+++ b/src/components/game/InstallButton.tsx
@@ -157,6 +157,18 @@ const InstallButton = ({ game, purchased, setOpenBuyGameModal, purchaseLoading }
     checkInstalled(game);
   }, [game._id]);
 
+  useEffect(() => {
+    const unlisten = listen('game-installation-changed', (event: any) => {
+      if (event.payload.gameId === game._id) {
+        setInstalled(event.payload.installed);
+      }
+    });
+
+    return () => {
+      unlisten.then(f => f());
+    };
+  }, [game._id]);
+
   const isDownloading = !!downloadStatusStore?.game_id;
   const isNativeGame = game?.projectMeta?.type === "native";
 

--- a/src/components/game/RemoveButton.tsx
+++ b/src/components/game/RemoveButton.tsx
@@ -40,7 +40,7 @@ const RemoveButton = ({ game }: IPropsRemoveButton) => {
     };
 
     checkInstalled(game);
-  }, [game]);
+  }, [game._id]);
 
   return (
     <>

--- a/src/components/game/RemoveButton.tsx
+++ b/src/components/game/RemoveButton.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 
 import { Button } from "@mui/material";
 import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
+import { listen } from "@tauri-apps/api/event";
 
 import { useNotification } from "../../providers/NotificationProvider";
 
@@ -40,6 +41,18 @@ const RemoveButton = ({ game }: IPropsRemoveButton) => {
     };
 
     checkInstalled(game);
+  }, [game._id]);
+
+  useEffect(() => {
+    const unlisten = listen('game-installation-changed', (event: any) => {
+      if (event.payload.gameId === game._id) {
+        setInstalled(event.payload.installed);
+      }
+    });
+
+    return () => {
+      unlisten.then(f => f());
+    };
   }, [game._id]);
 
   return (

--- a/src/lib/helper/DownloadHelper.ts
+++ b/src/lib/helper/DownloadHelper.ts
@@ -2,6 +2,7 @@ import { readDir } from "@tauri-apps/plugin-fs";
 import { appDataDir } from "@tauri-apps/api/path";
 import { type, arch } from "@tauri-apps/plugin-os";
 import { invoke } from "@tauri-apps/api/core";
+import { emit } from "@tauri-apps/api/event";
 import GameAPI from "../api/GameAPI";
 import { IGame, IGameReleaseNative } from "../../types/GameTypes";
 import { AuthAPI } from "../api/AuthAPI";
@@ -249,6 +250,8 @@ export const downloadAndInstallNewGame = async (game: IGame) => {
     await downloadFileToAppDir(game);
     await installGame(game);
     await deleteDownloadFile(game);
+    // Emit event after successful installation
+    await emit('game-installation-changed', { gameId: game._id, installed: true });
   } catch (err) {
     throw new Error(err.toString());
   }
@@ -597,6 +600,8 @@ export const deleteGameDirectory = async (game: IGame) => {
     await invoke("delete_directory", {
       dirLocation: directoryLocation,
     });
+    // Emit event after successful deletion
+    await emit('game-installation-changed', { gameId: game._id, installed: false });
   } catch (err) {
     console.error("Failed to deleteGameDirectory: ", err);
     throw new Error(err.toString());

--- a/src/lib/helper/DownloadHelper.ts
+++ b/src/lib/helper/DownloadHelper.ts
@@ -1,4 +1,3 @@
-import { readDir } from "@tauri-apps/plugin-fs";
 import { appDataDir } from "@tauri-apps/api/path";
 import { type, arch } from "@tauri-apps/plugin-os";
 import { invoke } from "@tauri-apps/api/core";
@@ -16,10 +15,13 @@ export async function runUrlArgs(url: string, args: string[]) {
 
 export async function isInstalled(game: IGame) {
   try {
-    await readDir(`${await appDataDir()}/games/${game.project_name}`);
-    return true;
+    console.time(`isInstalled check for ${game.project_name}`);
+    const path = `${await appDataDir()}/games/${game.project_name}`;
+    const exists = await invoke<boolean>('dir_exists', { path });
+    console.timeEnd(`isInstalled check for ${game.project_name}`);
+    return exists;
   } catch (err) {
-    // console.log("Failed to isInstalled: ", err);
+    console.error("Failed to check if installed: ", err);
     return false;
   }
 }

--- a/src/lib/helper/DownloadHelper.ts
+++ b/src/lib/helper/DownloadHelper.ts
@@ -2,7 +2,6 @@ import { readDir } from "@tauri-apps/plugin-fs";
 import { appDataDir } from "@tauri-apps/api/path";
 import { type, arch } from "@tauri-apps/plugin-os";
 import { invoke } from "@tauri-apps/api/core";
-import { CONFIG_TYMT_VERSION } from "../../config/MainConfig";
 import GameAPI from "../api/GameAPI";
 import { IGame, IGameReleaseNative } from "../../types/GameTypes";
 import { AuthAPI } from "../api/AuthAPI";
@@ -16,7 +15,7 @@ export async function runUrlArgs(url: string, args: string[]) {
 
 export async function isInstalled(game: IGame) {
   try {
-    await readDir(`${await appDataDir()}/v${CONFIG_TYMT_VERSION}/games/${game.project_name}`);
+    await readDir(`${await appDataDir()}/games/${game.project_name}`);
     return true;
   } catch (err) {
     // console.log("Failed to isInstalled: ", err);
@@ -310,7 +309,7 @@ export const getFullExecutablePathNewGame = async (game: IGame) => {
   try {
     const prefix: string = await appDataDir();
     const exePath: string = await getExecutablePathNewGame(game);
-    const fullPath = prefix + `/v${CONFIG_TYMT_VERSION}/games/${game.project_name}/` + exePath;
+    const fullPath = prefix + `/games/${game.project_name}/` + exePath;
     // console.log("getFullExecutablePathNewGame", fullPath);
     return fullPath;
   } catch (err) {
@@ -545,7 +544,7 @@ export const getDownloadFileFullPath = async (game: IGame) => {
 
 export const getInstallDir = async (game: IGame) => {
   try {
-    const res = `${await appDataDir()}/v${CONFIG_TYMT_VERSION}/games/${game?.project_name}`;
+    const res = `${await appDataDir()}/games/${game?.project_name}`;
     // console.log("getInstallDir", res);
     return res;
   } catch (err) {


### PR DESCRIPTION
This PR addresses critical usability issues related to the game install/play button.

- **`fix: os check`**: Use getGameReleaseNative to properly check platform support
- **`fix: concurrent downloads`**: Only block native downloads when native is downloading
- **`fix: game dl error handling`**: Replace panic! with proper error return
- **`security: add path traversal protection`**: Prevent Zip Slip attacks
- **`chore: update game dl paths`**: Remove version from storage paths
- **`fix: readDir spam`**: Change useEffect dependencies to prevent constant checks
- **`fix: sync install state`**: Add event system for installation state updates
- **`fix: install button spam`**: Prevent multiple clicks during installation
- **`fix: game page button delay`**: Replace slow readDir with fast dir_exists check